### PR TITLE
Additional work for K8s v1.6.3 and automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: all push
 
 all: .
-	docker build -t streamplace/kube-for-mac .
+	docker build -t andybrucenet/kube-for-mac .
 
 push: .
-	docker push streamplace/kube-for-mac
+	docker push andybrucenet/kube-for-mac

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: all push
 
 all: .
-	docker build -t andybrucenet/kube-for-mac .
+	docker build -t streamplace/kube-for-mac .
 
 push: .
-	docker push andybrucenet/kube-for-mac
+	docker push streamplace/kube-for-mac

--- a/Readme.md
+++ b/Readme.md
@@ -59,3 +59,118 @@ preferences: {}
 users:
 - name: kube-for-mac
 ```
+
+## What is this `run-docker-kube-for-mac.sh` thingie?
+
+It's a handy shell script that fires up the whole thing for you.
+
+And it is designed to account for - er, um - "improvements" to Kubernetes.
+
+Such as 1.6.3 that out-of-the-box guarantees breakage (if for nothing else the fact that API Server has a new default of etcd version 3 - while the out-of-the-box kubelet still builds etcd version 2).
+
+First, let's start everything with the v1.6.3 hacks:
+```
+CloudraticSolutionsLLCs-MacBook-Pro:kube-for-mac l.abruce$ ./hacks/v1.6.3/run ./run-docker-kube-for-mac.sh start
+Starting kube-for-mac...
+docker run --privileged -v /:/rootfs -v /Users:/Users \
+  --volume /Users/l.abruce/proj/docker/sab/kube-for-mac/hacks/v1.6.3:/etc/hacks-in:ro \
+  -d --name run-docker-kube-for-mac-start \
+  -e DOCKER_ARGS="--volume /etc/hacks/v1.6.3/kubelet/etc/kubernetes/manifests/master.json:/etc/kubernetes/manifests/master.json:ro" \
+  -e K8S_VERSION=1.6.3 \
+  -e KUBELET_ARGS="--cgroups-per-qos=false --enforce-node-allocatable=""" \
+  -e K8S_HACKS="/etc/hacks-in/hacks.sh" \
+  streamplace/kube-for-mac:latest
+228415e9cfea0905d2d4ab497c57264ef0c25b7e2457ef7f5807add2e76b110b
+Wait for start: .OK
+Wait for server: ..OK
+```
+
+This starts all of the required containers. Let's take a look at what got created:
+```
+CloudraticSolutionsLLCs-MacBook-Pro:kube-for-mac l.abruce$ kubectl get ns
+NAME          STATUS    AGE
+default       Active    21s
+kube-public   Active    20s
+kube-system   Active    21s
+CloudraticSolutionsLLCs-MacBook-Pro:kube-for-mac l.abruce$ kubectl --namespace=kube-system get pods
+NAME                                    READY     STATUS    RESTARTS   AGE
+k8s-master-127.0.0.1                    4/4       Running   1          26s
+kube-dns-806549836-78b1t                3/3       Running   0          20s
+kubernetes-dashboard-2917854236-bmrws   1/1       Running   0          21s
+```
+
+Let's run a simple container and verify that DNS works. (Which - just FYI - I cannot get to work with `kubeadm` on CentOS or Fedora. But does work here.)
+```
+CloudraticSolutionsLLCs-MacBook-Pro:kube-for-mac l.abruce$ kubectl run -i -t busybox --image=busybox --restart=Never
+If you don't see a command prompt, try pressing enter.
+/ # nslookup kubernetes
+Server:    10.0.0.10
+Address 1: 10.0.0.10 kube-dns.kube-system.svc.cluster.local
+
+Name:      kubernetes
+Address 1: 10.0.0.1 kubernetes.default.svc.cluster.local
+/ # exit
+```
+
+Take a quick peak at the pods:
+```
+CloudraticSolutionsLLCs-MacBook-Pro:kube-for-mac l.abruce$ kubectl get pods --show-all
+NAME      READY     STATUS      RESTARTS   AGE
+busybox   0/1       Completed   0          18s
+```
+
+Alright, I'm spent. Let's kill them all:
+```
+CloudraticSolutionsLLCs-MacBook-Pro:kube-for-mac l.abruce$ ./hacks/v1.6.3/run ./run-docker-kube-for-mac.sh stop
+Stopping kube-for-mac...
+docker run --privileged -v /:/rootfs -v /Users:/Users \
+  --volume /Users/l.abruce/proj/docker/sab/kube-for-mac/hacks/v1.6.3:/etc/hacks-in:ro \
+  -d --name run-docker-kube-for-mac-stop \
+  -e K8S_VERSION=1.6.3 \
+  -e K8S_HACKS="/etc/hacks-in/hacks.sh" \
+  streamplace/kube-for-mac:latest stop
+1948d282576b90379c2abf7568aa1a649b2b45821130090209067a0ee9698462
+Wait for stop: ..........OK
+
+>>>>>>>  Deleting Kubernetes cluster...
+kubelet
+k8s-proxy-1
+k8s-proxy-2
+
+>>>>>>>  Deleting all kubernetes containers...
+k8s_busybox_busybox_default_b3b2e79c-3a35-11e7-869c-ba4b3ade41c6_0
+k8s_POD_busybox_default_b3b2e79c-3a35-11e7-869c-ba4b3ade41c6_0
+k8s_sidecar_kube-dns-806549836-78b1t_kube-system_8eda149b-3a35-11e7-869c-ba4b3ade41c6_0
+k8s_dnsmasq_kube-dns-806549836-78b1t_kube-system_8eda149b-3a35-11e7-869c-ba4b3ade41c6_0
+k8s_kubedns_kube-dns-806549836-78b1t_kube-system_8eda149b-3a35-11e7-869c-ba4b3ade41c6_0
+k8s_POD_kube-dns-806549836-78b1t_kube-system_8eda149b-3a35-11e7-869c-ba4b3ade41c6_0
+k8s_kubernetes-dashboard_kubernetes-dashboard-2917854236-bmrws_kube-system_8e283f9d-3a35-11e7-869c-ba4b3ade41c6_0
+k8s_POD_kubernetes-dashboard-2917854236-bmrws_kube-system_8e283f9d-3a35-11e7-869c-ba4b3ade41c6_0
+k8s_apiserver_k8s-master-127.0.0.1_kube-system_46406242b8e4a9b7dee0f580bce8311d_1
+k8s_setup_k8s-master-127.0.0.1_kube-system_46406242b8e4a9b7dee0f580bce8311d_0
+k8s_scheduler_k8s-master-127.0.0.1_kube-system_46406242b8e4a9b7dee0f580bce8311d_0
+k8s_kube-addon-manager-data_kube-addon-manager-127.0.0.1_kube-system_6d93f1030e8e9e6e27f07f918bada68b_0
+k8s_apiserver_k8s-master-127.0.0.1_kube-system_46406242b8e4a9b7dee0f580bce8311d_0
+k8s_etcd_k8s-etcd-127.0.0.1_kube-system_ce41cb65bfba8d0e5f2575acaa3816ca_0
+k8s_controller-manager_k8s-master-127.0.0.1_kube-system_46406242b8e4a9b7dee0f580bce8311d_0
+k8s_kube-addon-manager_kube-addon-manager-127.0.0.1_kube-system_6d93f1030e8e9e6e27f07f918bada68b_0
+k8s_kube-proxy_k8s-proxy-127.0.0.1_kube-system_d00ccc45519f37e0b496f8ba2ebc1354_0
+k8s_POD_k8s-etcd-127.0.0.1_kube-system_ce41cb65bfba8d0e5f2575acaa3816ca_0
+k8s_POD_kube-addon-manager-127.0.0.1_kube-system_6d93f1030e8e9e6e27f07f918bada68b_0
+k8s_POD_k8s-master-127.0.0.1_kube-system_46406242b8e4a9b7dee0f580bce8311d_0
+k8s_POD_k8s-proxy-127.0.0.1_kube-system_d00ccc45519f37e0b496f8ba2ebc1354_0
+
+>>>>>>>  Deleting kube-for-mac startup container...
+streamplace/kube-for-mac:latest
+228415e9cfea
+
+>>>>>>>  Removing all kubelet mounts
+
+>>>>>>>  Removing /var/lib/kubelet
+
+>>>>>>>  Executing hack: '/etc/hacks-in/hacks.sh'
+Cleanup Docker Alpine folder...
+Remove our specific hacks folder...
+```
+
+That is all.

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -17,6 +17,18 @@ bigLog() {
   echo ">>>>>>> " $*
 }
 
+copyFile() {
+  local l_src="$1"; shift
+  local l_dst="$1"; shift
+  local l_flag='>'
+  #echo "l_src='$l_src'; l_dst='$l_dst'"
+  while IFS='' read -r LINE || [[ -n "$LINE" ]] ; do
+    #echo "LINE='$LINE'"
+    nsenter --mount=/rootfs/proc/1/ns/mnt -- ash -c "echo '$LINE' $l_flag '$l_dst'"
+    l_flag='>>'
+  done < "$l_src"
+}
+
 runWatcher() {
   onVM docker run \
     -d \
@@ -25,3 +37,4 @@ runWatcher() {
     -v /Users:/Users \
     streamplace/kube-for-mac /watcher-fix.sh "${1:-}"
 }
+

--- a/bin/start
+++ b/bin/start
@@ -12,10 +12,25 @@ if ! onVM which findmnt; then
   onVM apk update
   onVM apk add findmnt
 fi
+if ! onVM which mount.nfs; then
+  bigLog "Adding necessary dependency mount.nfs..."
+  onVM apk update
+  onVM apk add nfs-utils
+fi
 
 # I have no idea why this is, but once kubelet starts running it expects mount to be at /mount.
 bigLog "Copying mount for poorly-understood reasons..."
-onVM cp /bin/mount /mount
+if ! onVM ls /mount 2>/dev/null ; then
+  #onVM cp /bin/mount /mount
+  nsenter --mount=/rootfs/proc/1/ns/mnt -- ash -c "echo '#!/bin/sh' > /mount"
+  nsenter --mount=/rootfs/proc/1/ns/mnt -- ash -c "echo 'if /bin/echo \"\$*\" | /bin/grep -q -e \"-t nfs\" ; then' >> /mount"
+  nsenter --mount=/rootfs/proc/1/ns/mnt -- ash -c "echo '  the_good_value=\$(/bin/echo \"\$*\" | /bin/sed -e \"s/^\(.*\)-t nfs\(.*\)/\1-t nfs -o nolock \2/\")' >> /mount"
+  nsenter --mount=/rootfs/proc/1/ns/mnt -- ash -c "echo '  eval /bin/mount \$the_good_value' >> /mount"
+  nsenter --mount=/rootfs/proc/1/ns/mnt -- ash -c "echo 'else' >> /mount"
+  nsenter --mount=/rootfs/proc/1/ns/mnt -- ash -c "echo '  eval /bin/mount \$*' >> /mount"
+  nsenter --mount=/rootfs/proc/1/ns/mnt -- ash -c "echo 'fi' >> /mount"
+  onVM chmod +x /mount
+fi
 
 bigLog "Creating /var/lib/kubelet bind"
 onVM mkdir -p /var/lib/kubelet
@@ -28,28 +43,57 @@ for container in $CONTAINER_NAMES; do
   onVM docker rm -f $container > /dev/null || echo "No need to clean up $container"
 done
 
+# kubernetes version
+K8S_VERSION="${K8S_VERSION:-1.5.7}"
+
+my_start="/tmp/$$.my_start"
+bigLog "Writing $my_start..."
+cat > "$my_start" <<EOF
+onVM docker run \\
+  --net=host \\
+  --pid=host \\
+  --privileged \\
+  --volume=/:/rootfs:ro \\
+  --volume=/sys:/sys:ro \\
+  --volume=/var/run:/var/run:rw \\
+  --volume=/var/lib/docker/:/var/lib/docker:rw \\
+  --volume=/var/lib/kubelet/:/var/lib/kubelet:shared \\
+  --name=kubelet \\
+  -d \\
+  $DOCKER_ARGS \\
+  gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \\
+  /hyperkube kubelet \\
+    --address="0.0.0.0" \\
+    --containerized \\
+    --hostname-override="127.0.0.1" \\
+    --api-servers=http://localhost:8080 \\
+    --pod-manifest-path=/etc/kubernetes/manifests \\
+    --cluster-dns=10.0.0.10 \\
+    --cluster-domain=cluster.local \\
+    --allow-privileged=true --v=5 \\
+    $KUBELET_ARGS
+EOF
+cat "$my_start"
+
+# handle hacks (thanks, Kubernetes Authors)
+if [ x"$K8S_HACKS" != x ]; then
+  for i in $(echo "$K8S_HACKS") ; do
+    bigLog "Executing hack: '$i'"
+    source "$i" PRESTART
+  done
+fi
+
 bigLog "Starting kubelet..."
-onVM docker run \
-  --net=host \
-  --pid=host \
-  --privileged \
-  --volume=/:/rootfs:ro \
-  --volume=/sys:/sys:ro \
-  --volume=/var/run:/var/run:rw \
-  --volume=/var/lib/docker/:/var/lib/docker:rw \
-  --volume=/var/lib/kubelet/:/var/lib/kubelet:shared \
-  --name=kubelet \
-  -d \
-  gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION:-1.5.5} \
-  /hyperkube kubelet \
-    --address="0.0.0.0" \
-    --containerized \
-    --hostname-override="127.0.0.1" \
-    --api-servers=http://localhost:8080 \
-    --pod-manifest-path=/etc/kubernetes/manifests \
-    --cluster-dns=10.0.0.10 \
-    --cluster-domain=cluster.local \
-    --allow-privileged=true --v=2
+source "$my_start"
+rm -f "$my_start"
+
+# handle hacks (thanks, Kubernetes Authors)
+if [ x"$K8S_HACKS" != x ]; then
+  for i in $(echo "$K8S_HACKS") ; do
+    bigLog "Executing hack: '$i'"
+    source "$i" POSTSTART
+  done
+fi
 
 onVM rm -rf /tmp/kubernetes.sock
 
@@ -76,3 +120,4 @@ bigLog "Done. Give it like three minutes than see if you can curl localhost:8888
 
 bigLog "This container has to keep running because of a strange kube-for-mac file watching bug. https://git.io/vSejZ"
 tail -f /dev/null
+

--- a/bin/stop
+++ b/bin/stop
@@ -34,11 +34,19 @@ for container in $allContainers; do
 done
 
 bigLog "Removing all kubelet mounts"
-allMounts="$(onVM mount | awk '{print $3;}' | grep kubelet || true)"
-mounts="$(echo $allMounts | sort | uniq)"
-for thisMount in $mounts; do
+kubeletMounts="$(onVM mount | awk '{print $3;}' | grep kubelet | sort | uniq | sort -r)"
+for thisMount in $kubeletMounts; do
   onVM umount "$thisMount"
 done
 
 bigLog "Removing /var/lib/kubelet"
 onVM rm -rf /var/lib/kubelet
+
+# handle hacks (thanks, Kubernetes Authors)
+if [ x"$K8S_HACKS" != x ]; then
+  for i in $(echo "$K8S_HACKS") ; do
+    bigLog "Executing hack: '$i'"
+    source "$i" CLEANUP
+  done
+fi
+

--- a/hacks/v1.6.3/hacks.sh
+++ b/hacks/v1.6.3/hacks.sh
@@ -2,10 +2,10 @@
 
 if [ x"$1" = 'xPRESTART' ] ; then
   # tell user we are here
-  echo "Hacking at Docker Alpine... "
+  echo "Hacking at Docker Alpine..."
 
   # create folder on alpine docker
-  echo "Create folder on Docker Alpine... "
+  echo "Create folder on Docker Alpine..."
   onVM mkdir -p "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests"
 
   # the only way I can find to override the master.json file
@@ -15,8 +15,14 @@ if [ x"$1" = 'xPRESTART' ] ; then
   # cat it out
   echo "Cat master.json override..."
   onVM cat "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests/master.json"
+fi
 
-  #echo "Sleep for a while..."
-  #sleep 10000
+if [ x"$1" = 'xCLEANUP' ] ; then
+  # tell user we are here
+  echo "Cleanup Docker Alpine folder..."
+
+  # create folder on alpine docker
+  echo "Remove our specific hacks folder..."
+  onVM rm -fR /etc/hacks
 fi
 

--- a/hacks/v1.6.3/hacks.sh
+++ b/hacks/v1.6.3/hacks.sh
@@ -1,0 +1,22 @@
+# this hack is run for 1.6.3
+
+if [ x"$1" = 'xPRESTART' ] ; then
+  # tell user we are here
+  echo "Hacking at Docker Alpine... "
+
+  # create folder on alpine docker
+  echo "Create folder on Docker Alpine... "
+  onVM mkdir -p "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests"
+
+  # the only way I can find to override the master.json file
+  echo "Copy master.json override..."
+  copyFile '/etc/hacks-in/kubelet/etc/kubernetes/manifests/master.json' "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests/master.json"
+
+  # cat it out
+  echo "Cat master.json override..."
+  onVM cat "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests/master.json"
+
+  #echo "Sleep for a while..."
+  #sleep 10000
+fi
+

--- a/hacks/v1.6.3/kubelet/etc/kubernetes/manifests/master.json
+++ b/hacks/v1.6.3/kubelet/etc/kubernetes/manifests/master.json
@@ -1,0 +1,92 @@
+{
+"apiVersion": "v1",
+"kind": "Pod",
+"metadata": {
+  "name": "k8s-master",
+  "namespace": "kube-system"
+},
+"spec":{
+  "hostNetwork": true,
+  "containers":[
+    {
+      "name": "controller-manager",
+      "image": "gcr.io/google_containers/hyperkube-amd64:v1.6.3",
+      "command": [
+        "/hyperkube",
+        "controller-manager",
+        "--master=127.0.0.1:8080",
+        "--service-account-private-key-file=/srv/kubernetes/server.key",
+        "--root-ca-file=/srv/kubernetes/ca.crt",
+        "--min-resync-period=3m",
+        "--leader-elect=true",
+        "--v=2"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    },
+    {
+      "name": "apiserver",
+      "image": "gcr.io/google_containers/hyperkube-amd64:v1.6.3",
+      "command": [
+        "/hyperkube",
+        "apiserver",
+        "--service-cluster-ip-range=10.0.0.1/24",
+        "--insecure-bind-address=127.0.0.1",
+        "--etcd-servers=http://127.0.0.1:2379",
+        "--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
+        "--client-ca-file=/srv/kubernetes/ca.crt",
+        "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
+        "--min-request-timeout=300",
+        "--tls-cert-file=/srv/kubernetes/server.cert",
+        "--tls-private-key-file=/srv/kubernetes/server.key",
+        "--token-auth-file=/srv/kubernetes/known_tokens.csv",
+        "--allow-privileged=true",
+        "--storage-backend=etcd2",
+        "--v=2"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    },
+    {
+      "name": "scheduler",
+      "image": "gcr.io/google_containers/hyperkube-amd64:v1.6.3",
+      "command": [
+        "/hyperkube",
+        "scheduler",
+        "--master=127.0.0.1:8080",
+        "--leader-elect=true",
+        "--v=2"
+      ]
+    },
+    {
+      "name": "setup",
+      "image": "gcr.io/google_containers/hyperkube-amd64:v1.6.3",
+      "command": [
+        "/setup-files.sh",
+        "IP:10.0.0.1,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "name": "data",
+      "emptyDir": {}
+    }
+  ]
+ }
+}
+

--- a/hacks/v1.6.3/run
+++ b/hacks/v1.6.3/run
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# local folder
+g_CURDIR="$(pwd)"
+g_SCRIPT_FOLDER_RELATIVE=$(dirname "$0")
+cd "$g_SCRIPT_FOLDER_RELATIVE"
+g_SCRIPT_FOLDER_ABSOLUTE="$(pwd)"
+cd "$g_CURDIR"
+
+# hacks to get Kubernetes 1.6.3 to work
+  # local invocation - map the hacks folder for the initial start script
+export DOCKER_KUBE_FOR_MAC_LOCAL_DOCKER_ARGS="--volume $g_SCRIPT_FOLDER_ABSOLUTE:/etc/hacks-in:ro"
+  # the kubernetes version to instantiate
+export DOCKER_KUBE_FOR_MAC_K8S_VERSION=1.6.3
+  # tell invoked docker to mount the hacks passed in to us
+export DOCKER_KUBE_FOR_MAC_DOCKER_ARGS="--volume /etc/hacks/v$DOCKER_KUBE_FOR_MAC_K8S_VERSION/kubelet/etc/kubernetes/manifests/master.json:/etc/kubernetes/manifests/master.json:ro"
+  # k8s v1.6 requires cgroups which are not compatible with Docker for Mac
+export DOCKER_KUBE_FOR_MAC_KUBELET_ARGS='--cgroups-per-qos=false --enforce-node-allocatable=""'
+  # specific hack script to force apiserver to use etcd v2
+export DOCKER_KUBE_FOR_MAC_K8S_HACKS='"/etc/hacks-in/hacks.sh"'
+
+# call whatever was passed in
+eval "$@"
+

--- a/hacks/v1.6.3/run
+++ b/hacks/v1.6.3/run
@@ -17,7 +17,7 @@ export DOCKER_KUBE_FOR_MAC_DOCKER_ARGS="--volume /etc/hacks/v$DOCKER_KUBE_FOR_MA
   # k8s v1.6 requires cgroups which are not compatible with Docker for Mac
 export DOCKER_KUBE_FOR_MAC_KUBELET_ARGS='--cgroups-per-qos=false --enforce-node-allocatable=""'
   # specific hack script to force apiserver to use etcd v2
-export DOCKER_KUBE_FOR_MAC_K8S_HACKS='"/etc/hacks-in/hacks.sh"'
+export DOCKER_KUBE_FOR_MAC_K8S_HACKS='/etc/hacks-in/hacks.sh'
 
 # call whatever was passed in
 eval "$@"

--- a/run-docker-kube-for-mac.sh
+++ b/run-docker-kube-for-mac.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# run-docker-kube-for-mac.sh, ABr
+# Run kubernetes natively on Mac OsX
+# See https://github.com/streamplace/kube-for-mac
+
+########################################################################
+# globals
+g_DOCKER_KUBE_FOR_MAC_IMAGE="${DOCKER_KUBE_FOR_MAC_IMAGE:-dockerregistry.hlsdev.local:5000/hlsdev/kube-for-mac:1.0}"
+g_DOCKER_KUBE_FOR_MAC_K8S_VERSION="${DOCKER_KUBE_FOR_MAC_K8S_VERSION:-1.5.7}"
+g_DOCKER_KUBE_FOR_MAC_DOCKER_ARGS="${DOCKER_KUBE_FOR_MAC_DOCKER_ARGS}"
+g_DOCKER_KUBE_FOR_MAC_KUBELET_ARGS="${DOCKER_KUBE_FOR_MAC_KUBELET_ARGS}"
+g_DOCKER_KUBE_FOR_MAC_LOCAL_DOCKER_ARGS="${DOCKER_KUBE_FOR_MAC_LOCAL_DOCKER_ARGS}"
+g_DOCKER_KUBE_FOR_MAC_K8S_HACKS="${DOCKER_KUBE_FOR_MAC_K8S_HACKS}"
+
+########################################################################
+# start
+function run-docker-kube-for-mac-x-start {
+  local l_container_id=$(docker ps --quiet --filter name=run-docker-kube-for-mac-start 2>/dev/null)
+  [ x"$l_container_id" != x ] && echo 'Container already running.' && return 1
+
+  # allow overrides
+  local LOCAL_DOCKER_ARGS="$g_DOCKER_KUBE_FOR_MAC_DOCKER_ARGS"
+  local LOCAL_KUBELET_ARGS="$g_DOCKER_KUBE_FOR_MAC_KUBELET_ARGS"
+  local LOCAL_K8S_HACKS="$g_DOCKER_KUBE_FOR_MAC_K8S_HACKS"
+
+  echo 'Starting kube-for-mac...'
+  local l_docker_run="/tmp/$$.dockerrun"
+  echo "docker run --privileged -v /:/rootfs -v /Users:/Users \\" > "$l_docker_run"
+	[ x"$g_DOCKER_KUBE_FOR_MAC_LOCAL_DOCKER_ARGS" != x ] && echo "  $g_DOCKER_KUBE_FOR_MAC_LOCAL_DOCKER_ARGS \\" >> "$l_docker_run"
+  echo "  -d --name run-docker-kube-for-mac-start \\" >> "$l_docker_run"
+  echo "  -e DOCKER_ARGS=\"$LOCAL_DOCKER_ARGS\" \\" >> "$l_docker_run"
+  echo "  -e K8S_VERSION=$g_DOCKER_KUBE_FOR_MAC_K8S_VERSION \\" >> "$l_docker_run"
+  echo "  -e KUBELET_ARGS=\"$LOCAL_KUBELET_ARGS\" \\" >> "$l_docker_run"
+  echo "  -e K8S_HACKS=\"$LOCAL_K8S_HACKS\" \\" >> "$l_docker_run"
+  echo "  $g_DOCKER_KUBE_FOR_MAC_IMAGE" >> "$l_docker_run"
+	cat "$l_docker_run"
+	source "$l_docker_run"
+  local l_rc=$?
+	rm -f "$l_docker_run"
+set +x
+  [ $l_rc -ne 0 ] && return $l_rc
+  echo -n 'Wait for start: '
+  local l_ctr=0
+  local l_timeout=90
+  local l_status=''
+  while [ $l_ctr -lt $l_timeout ] ; do
+    l_ctr=$((l_ctr + 1))
+    l_container_id=$(docker ps --quiet --filter name=run-docker-kube-for-mac-start 2>/dev/null)
+    [ x"$l_container_id" = x ] && sleep 5 && echo -n '.' && continue
+
+    # get the status
+    l_status=$(docker logs $l_container_id 2>/dev/null | grep -e '^>\+\s\+Done\.')
+    [ x"$l_status" = x ] && sleep 5 && echo -n '.' && continue
+    break
+  done
+  [ x"$l_container_id" = x ] && echo '**CONTAINER NOT FOUND**' && return 1
+  [ x"$l_status" = x ] && echo '**TIMEOUT**' && return 1
+
+  # wait for container to be available
+  echo 'OK'
+  echo -n 'Wait for server: '
+  l_ctr=0
+  l_timeout=56
+  while [ $l_ctr -lt $l_timeout ] ; do
+    l_ctr=$((l_ctr + 1))
+    curl localhost:8888 >/dev/null 2>&1
+    l_rc=$?
+    [ $l_rc -ne 0 ] && sleep 5 && echo -n '.' && continue
+    break
+  done
+  [ $l_rc -ne 0 ] && echo '**TIMEOUT**' && return 1
+  echo 'OK'
+  return 0
+}
+ 
+########################################################################
+# stop
+function run-docker-kube-for-mac-x-stop {
+  echo 'Stopping kube-for-mac...'
+  docker run --rm --privileged -v /:/rootfs -v /Users:/Users \
+    -d --name=run-docker-kube-for-mac-stop \
+    $g_DOCKER_KUBE_FOR_MAC_IMAGE stop
+  local l_rc=$?
+  [ $l_rc -ne 0 ] && return $l_rc
+  echo -n 'Wait for stop: '
+  local l_container_id=''
+  local l_ctr=0
+  local l_timeout=90
+  while [ $l_ctr -lt $l_timeout ] ; do
+    sleep 1
+    l_ctr=$((l_ctr + 1))
+    l_container_id=$(docker ps --quiet --filter name=run-docker-kube-for-mac-stop 2>/dev/null)
+    [ x"$l_container_id" != x ] && echo -n '.' && continue
+    break
+  done
+  [ x"$l_container_id" != x ] && echo '**TIMEOUT**' && return 1
+  echo 'OK'
+  l_container_id=$(docker ps --quiet --filter name=run-docker-kube-for-mac-start 2>/dev/null)
+  if [ x"$l_container_id" != x ] ; then
+    echo 'Remove kube-for-mac...'
+    docker rm --force run-docker-kube-for-mac-start
+    l_rc=$?
+    [ $l_rc -ne 0 ] && return $l_rc
+  fi
+  return 0
+}
+ 
+########################################################################
+# restart
+function run-docker-kube-for-mac-x-restart {
+  run-docker-kube-for-mac-x-stop
+  sleep 3
+  run-docker-kube-for-mac-x-start
+}
+ 
+########################################################################
+# optional call support
+l_do_run=0
+if [ "x$1" != "x" ]; then
+  [ "x$1" != "xsource-only" ] && l_do_run=1
+fi
+if [ $l_do_run -eq 1 ]; then
+  l_func="$1"; shift
+  [ x"$l_func" != x ] && eval run-docker-kube-for-mac-x-"$l_func" $*
+fi
+


### PR DESCRIPTION
1. Created helper shell script to spawn off the Kubernetes cluster
1. Worked around breaking v1.6.3 changes. Specifically, `master.json` on the Kubelet which creates an API Server that uses the new default of etcd V3 - while the etcd JSON still creates etcd V2.

On the etcd issue, see:

- https://github.com/coreos/etcd/issues/5429 - This showed the transport error I received when running Kubelet out-of-the-box with default container creation.
- https://github.com/kubernetes/kubernetes/issues/39710 - This discusses the problem and indicates it is fixed - but I'm not sure which completed gcr image has the fix as v1.6.3 certainly does break.

On a separate note, I do not like the way I'm overriding the `master.json` deployment. I would much rather tie into how Kubelet creates `/etc/kubernetes/manifests` (it is not on the BASEIMAGE so it must be created dynamically). I just cannot find out how to intercept the creation and either modify the etcd creation to use version 3 (different container image) or add the appropriate `--storage-backend` option to the API Server container creation yaml.
