### PR TITLE
Updates for v1.7.3 and additional automation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 node_modules
+*~
+.git
+.vagrant
+*.pyc
+*.pyo
+.idea
+*.swp
+.DS_Store
+

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# handle debug
+if [ x"$K8S_DEBUG" = x1 ] ; then
+  set -x
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export CONTAINER_NAMES="kubelet k8s-proxy-1 k8s-proxy-2"

--- a/cli.js
+++ b/cli.js
@@ -26,14 +26,13 @@ var run = function(cmd, args) {
 require("yargs")
   .command("start", "destroy your local kube-for-mac installation", argv => {
     run("docker rm -f /docker-kube-for-mac-start", { errorsAreOkay: true });
-    run("./hacks/v1.7.0/run ./run-docker-kube-for-mac.sh start");
-    run(
-      "./hacks/v1.7.0/run ./run-docker-kube-for-mac.sh custom source /etc/hacks-in/hacks.sh DEPLOY-ADDONS"
-    );
+    run("./hacks/v1.7.3/run ./run-docker-kube-for-mac.sh start");
+    run("./hacks/v1.7.3/run ./run-docker-kube-for-mac.sh custom source /etc/hacks-in/hacks.sh DEPLOY-DNS");
+    run("./hacks/v1.7.3/run ./run-docker-kube-for-mac.sh custom source /etc/hacks-in/hacks.sh DEPLOY-DASHBOARD");
     run("docker logs -f docker-kube-for-mac-custom", { errorsAreOkay: true });
   })
   .command("destroy", "start a local kube-for-mac installation", argv => {
-    run("./hacks/v1.7.0/run ./run-docker-kube-for-mac.sh stop");
+    run("./hacks/v1.7.3/run ./run-docker-kube-for-mac.sh stop");
   })
   .showHelpOnFail(true)
   .demandCommand()

--- a/hacks/v1.7.3/hacks.sh
+++ b/hacks/v1.7.3/hacks.sh
@@ -1,0 +1,97 @@
+# this hack is run for 1.7.3
+
+if [ x"$1" = 'xPRESTART' ] ; then
+  # tell user we are here
+  echo "Hacking at Docker Alpine..."
+
+  # create folder on alpine docker
+  echo "Create folders on Docker Alpine..."
+  onVM mkdir -p "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests"
+  onVM mkdir -p "/etc/hacks/v$K8S_VERSION/apiserver/srv/kubernetes"
+  onVM mkdir -p "/etc/hacks/v$K8S_VERSION/kube-addon-manager/etc/kubernetes/addons"
+  onVM mkdir -p "/etc/hacks/v$K8S_VERSION/kube-addon-manager/staging"
+
+  # v1.7.0: default manifests aren't created. fudge.
+  echo "Copy kubelet manifests..."
+  copyFile '/etc/hacks-in/kubelet/etc/kubernetes/manifests/addon-manager-singlenode.json' "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests/addon-manager-singlenode.json"
+  copyFile '/etc/hacks-in/kubelet/etc/kubernetes/manifests/etcd.json' "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests/etcd.json"
+  copyFile '/etc/hacks-in/kubelet/etc/kubernetes/manifests/kube-proxy.json' "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests/kube-proxy.json"
+  copyFile '/etc/hacks-in/kubelet/etc/kubernetes/manifests/master.json' "/etc/hacks/v$K8S_VERSION/kubelet/etc/kubernetes/manifests/master.json"
+
+  # v1.7.0: tls is not automatically initialized either. eck.
+  set +e
+  bigLog "About to hack TLS..."
+  handle_tls
+  bigLog "Hacked TLS."
+  set -e
+
+  # v1.7.0: addons are not deployed (DNS / dashboard). [urp]
+  echo "Copy kube-addon-manager manifests (initial)..."
+  copyFile '/etc/hacks-in/kube-addon-manager/etc/kubernetes/addons/dashboard-service.yaml' "/etc/hacks/v$K8S_VERSION/kube-addon-manager/etc/kubernetes/addons/dashboard-service.yaml"
+  copyFile '/etc/hacks-in/kube-addon-manager/etc/kubernetes/addons/kubedns-cm.yaml' "/etc/hacks/v$K8S_VERSION/kube-addon-manager/etc/kubernetes/addons/kubedns-cm.yaml"
+  copyFile '/etc/hacks-in/kube-addon-manager/etc/kubernetes/addons/kubedns-sa.yaml' "/etc/hacks/v$K8S_VERSION/kube-addon-manager/etc/kubernetes/addons/kubedns-sa.yaml"
+  copyFile '/etc/hacks-in/kube-addon-manager/etc/kubernetes/addons/kubedns-svc.yaml' "/etc/hacks/v$K8S_VERSION/kube-addon-manager/etc/kubernetes/addons/kubedns-svc.yaml"
+  echo "Cannot deploy DNS/Dashboard addon controllers now...use DEPLOY-ADDONS option"
+fi
+
+if [ x"$1" = 'xDEPLOY-DNS' ] ; then
+  set +e
+  echo 'Wait for kube-addon-manager...'
+  the_ctr=0
+  the_timeout=60
+  while [ $the_ctr -lt $the_timeout ] ; do
+    the_ctr=$((the_ctr + 1))
+    the_addon_mgr=$(onVM docker ps | grep kube-addon-manager | grep -v POD | awk '{print $1}')
+    if [ x"$the_addon_mgr" != x ] ; then
+      if onVM docker logs $the_addon_mgr 2>&1 | grep -q -i -e 'Kubernetes addon reconcile completed' ; then
+        break
+      fi
+      the_addon_mgr=''
+    fi
+    echo -n '.'
+    sleep 3
+  done
+  [ x"$the_addon_mgr" = x ] && echo '***TIMEOUT***' && exit 1
+  echo 'OK'
+  #echo 'Sleeping for 120 seconds...'
+  #sleep 120
+
+  echo 'Deploy DNS...'
+  copyFile '/etc/hacks-in/kube-addon-manager/etc/kubernetes/addons/kubedns-controller.yaml' "/etc/hacks/v$K8S_VERSION/kube-addon-manager/etc/kubernetes/addons/kubedns-controller.yaml"
+  echo -n 'Wait: '
+  the_ctr=0
+  the_timeout=60
+  while [ $the_ctr -lt $the_timeout ] ; do
+    the_ctr=$((the_ctr + 1))
+    the_dns=$(onVM docker ps 2>&1 | grep k8s-dns-kube-dns-amd64 | awk '{print $1}')
+    if [ x"$the_dns" != x ] ; then
+      if ! onVM docker logs $the_dns 2>&1 | grep -q -i -e 'ready for queries' ;
+      then
+        the_dns=''
+      fi
+    fi
+    [ x"$the_dns" != x ] && break
+    echo -n '.'
+    sleep 3
+  done
+  [ x"$the_dns" = x ] && echo '***TIMEOUT***' && exit 1
+  echo 'OK'
+fi
+
+if [ x"$1" = 'xDEPLOY-DASHBOARD' ] ; then
+  set +e
+  # we won't wait for this...just do it
+  echo -n 'Deploy Dashboard: '
+  copyFile '/etc/hacks-in/kube-addon-manager/etc/kubernetes/addons/dashboard-controller.yaml' "/etc/hacks/v$K8S_VERSION/kube-addon-manager/etc/kubernetes/addons/dashboard-controller.yaml"
+  echo 'OK'
+fi
+
+if [ x"$1" = 'xCLEANUP' ] ; then
+  # tell user we are here
+  echo "Cleanup Docker Alpine folder..."
+
+  # create folder on alpine docker
+  echo "Remove our specific hacks folder..."
+  onVM rm -fR /etc/hacks/v$K8S_VERSION
+fi
+

--- a/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/dashboard-controller.yaml
+++ b/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/dashboard-controller.yaml
@@ -1,0 +1,62 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubernetes-dashboard
+  namespace: kube-system
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      creationTimestamp: null
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      containers:
+      - image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 9090
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 33
+          successThreshold: 1
+          timeoutSeconds: 30
+        name: kubernetes-dashboard
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+

--- a/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/dashboard-service.yaml
+++ b/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/dashboard-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-dashboard
+  namespace: kube-system
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    k8s-app: kubernetes-dashboard
+  ports:
+  - port: 80
+    targetPort: 9090
+

--- a/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/kubedns-cm.yaml
+++ b/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/kubedns-cm.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+

--- a/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/kubedns-controller.yaml
+++ b/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/kubedns-controller.yaml
@@ -1,0 +1,166 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      creationTimestamp: null
+      labels:
+        k8s-app: kube-dns
+    spec:
+      containers:
+      - args:
+        - --domain=cluster.local.
+        - --dns-port=10053
+        - --config-dir=/kube-dns-config
+        - --v=5
+        env:
+        - name: PROMETHEUS_PORT
+          value: "10055"
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthcheck/kubedns
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: kubedns
+        ports:
+        - containerPort: 10053
+          name: dns-local
+          protocol: UDP
+        - containerPort: 10053
+          name: dns-tcp-local
+          protocol: TCP
+        - containerPort: 10055
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readiness
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 35
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /kube-dns-config
+          name: kube-dns-config
+      - args:
+        - -v=5
+        - -logtostderr
+        - -configDir=/etc/k8s/dns/dnsmasq-nanny
+        - -restartDnsmasq=true
+        - --
+        - -k
+        - --cache-size=1000
+        - --log-facility=-
+        - --server=/cluster.local/127.0.0.1#10053
+        - --server=/in-addr.arpa/127.0.0.1#10053
+        - --server=/ip6.arpa/127.0.0.1#10053
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthcheck/dnsmasq
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 38
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: dnsmasq
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 150m
+            memory: 20Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/k8s/dns/dnsmasq-nanny
+          name: kube-dns-config
+      - args:
+        - --v=5
+        - --logtostderr
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,A
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,A
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /metrics
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 28
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: sidecar
+        ports:
+        - containerPort: 10054
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: Default
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: kube-dns
+      serviceAccountName: kube-dns
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: kube-dns
+          optional: true
+        name: kube-dns-config
+

--- a/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/kubedns-sa.yaml
+++ b/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/kubedns-sa.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+

--- a/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/kubedns-svc.yaml
+++ b/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons/kubedns-svc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: 10.0.0.10
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+

--- a/hacks/v1.7.3/kubelet/etc/kubernetes/manifests/addon-manager-singlenode.json
+++ b/hacks/v1.7.3/kubelet/etc/kubernetes/manifests/addon-manager-singlenode.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "kube-addon-manager",
+    "namespace": "kube-system",
+    "version": "v1"
+  },
+  "spec": {
+    "hostNetwork": true,
+    "containers": [
+      {
+        "name": "kube-addon-manager",
+        "image": "gcr.io/google_containers/kube-addon-manager-amd64:v6.4-beta.2",
+        "resources": {
+          "requests": {
+            "cpu": "5m",
+            "memory": "50Mi"
+          }
+        },
+        "volumeMounts": [
+          {
+            "name": "addons",
+            "mountPath": "/etc/kubernetes/addons",
+            "readOnly": true
+          }
+        ]
+      }
+    ],
+    "volumes":[
+      {
+        "name": "addons",
+        "hostPath": {
+          "path": "/etc/hacks/v1.7.3/kube-addon-manager/etc/kubernetes/addons"
+        }
+      }
+    ]
+  }
+}
+

--- a/hacks/v1.7.3/kubelet/etc/kubernetes/manifests/etcd.json
+++ b/hacks/v1.7.3/kubelet/etc/kubernetes/manifests/etcd.json
@@ -1,0 +1,37 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "k8s-etcd",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "hostNetwork": true,
+    "containers": [
+      {
+        "name": "etcd",
+        "image": "gcr.io/google_containers/etcd-amd64:3.0.17",
+        "command": [
+          "/usr/local/bin/etcd",
+          "--listen-client-urls=http://127.0.0.1:2379,http://127.0.0.1:4001",
+          "--advertise-client-urls=http://127.0.0.1:2379,http://127.0.0.1:4001",
+          "--data-dir=/var/etcd/data"
+        ],
+        "volumeMounts": [
+          {
+            "name": "varetcd",
+            "mountPath": "/var/etcd",
+            "readOnly": false
+          }
+        ]
+      }
+    ],
+    "volumes":[
+      {
+        "name": "varetcd",
+        "emptyDir": {}
+      }
+    ]
+  }
+}
+

--- a/hacks/v1.7.3/kubelet/etc/kubernetes/manifests/kube-proxy.json
+++ b/hacks/v1.7.3/kubelet/etc/kubernetes/manifests/kube-proxy.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "k8s-proxy",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "hostNetwork": true,
+    "containers": [
+      {
+        "name": "kube-proxy",
+        "image": "gcr.io/google_containers/hyperkube-amd64:v1.7.3",
+        "command": [
+          "/hyperkube",
+          "proxy",
+          "--master=http://127.0.0.1:8080",
+          "--v=2",
+          "--resource-container=\"\""
+        ],
+        "securityContext": {
+          "privileged": true
+        }
+      }
+    ]
+  }
+}

--- a/hacks/v1.7.3/kubelet/etc/kubernetes/manifests/master.json
+++ b/hacks/v1.7.3/kubelet/etc/kubernetes/manifests/master.json
@@ -1,0 +1,79 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "k8s-master",
+    "namespace": "kube-system"
+  },
+  "spec":{
+    "hostNetwork": true,
+    "containers":[
+      {
+        "name": "controller-manager",
+        "image": "gcr.io/google_containers/hyperkube-amd64:v1.7.3",
+        "command": [
+          "/hyperkube",
+          "controller-manager",
+          "--master=127.0.0.1:8080",
+          "--service-account-private-key-file=/srv/kubernetes/server.key",
+          "--root-ca-file=/srv/kubernetes/ca.crt",
+          "--min-resync-period=3m",
+          "--leader-elect=true",
+          "--v=2"
+        ],
+        "volumeMounts": [
+          {
+            "name": "data",
+            "mountPath": "/srv/kubernetes"
+          }
+        ]
+      },
+      {
+        "name": "apiserver",
+        "image": "gcr.io/google_containers/hyperkube-amd64:v1.7.3",
+        "command": [
+          "/hyperkube",
+          "apiserver",
+          "--service-cluster-ip-range=10.0.0.1/24",
+          "--insecure-bind-address=127.0.0.1",
+          "--etcd-servers=http://127.0.0.1:2379",
+          "--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
+          "--client-ca-file=/srv/kubernetes/ca.crt",
+          "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
+          "--min-request-timeout=300",
+          "--tls-cert-file=/srv/kubernetes/server.cert",
+          "--tls-private-key-file=/srv/kubernetes/server.key",
+          "--token-auth-file=/srv/kubernetes/known_tokens.csv",
+          "--allow-privileged=true",
+          "--v=2"
+        ],
+        "volumeMounts": [
+          {
+            "name": "data",
+            "mountPath": "/srv/kubernetes"
+          }
+        ]
+      },
+      {
+        "name": "scheduler",
+        "image": "gcr.io/google_containers/hyperkube-amd64:v1.7.3",
+        "command": [
+          "/hyperkube",
+          "scheduler",
+          "--master=127.0.0.1:8080",
+          "--leader-elect=true",
+          "--v=2"
+        ]
+      }
+    ],
+    "volumes": [
+      {
+        "name": "data",
+        "hostPath": {
+          "path": "/etc/hacks/v1.7.3/apiserver/srv/kubernetes"
+        }
+      }
+    ]
+  }
+}
+

--- a/hacks/v1.7.3/run
+++ b/hacks/v1.7.3/run
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# local folder
+g_CURDIR="$(pwd)"
+g_SCRIPT_FOLDER_RELATIVE=$(dirname "$0")
+cd "$g_SCRIPT_FOLDER_RELATIVE"
+g_SCRIPT_FOLDER_ABSOLUTE="$(pwd)"
+cd "$g_CURDIR"
+
+# hacks to get Kubernetes 1.7.3 to work
+  # local invocation - map the hacks folder for the initial start script
+export DOCKER_KUBE_FOR_MAC_LOCAL_DOCKER_ARGS="--volume $g_SCRIPT_FOLDER_ABSOLUTE:/etc/hacks-in:ro"
+  # the kubernetes version to instantiate
+export DOCKER_KUBE_FOR_MAC_K8S_VERSION=1.7.3
+  # tell invoked docker to mount the hacks passed in to us
+export DOCKER_KUBE_FOR_MAC_DOCKER_ARGS="--volume /etc/hacks/v$DOCKER_KUBE_FOR_MAC_K8S_VERSION/kubelet/etc/kubernetes/manifests:/etc/kubernetes/manifests:ro --volume /Users:/Users:rw"
+  # k8s v1.7 requires cgroups which are not compatible with Docker for Mac
+export DOCKER_KUBE_FOR_MAC_KUBELET_ARGS="--cgroups-per-qos=false --enforce-node-allocatable='' --cpu-cfs-quota=false"
+  # specific hack script to force apiserver to use etcd v2
+export DOCKER_KUBE_FOR_MAC_K8S_HACKS='/etc/hacks-in/hacks.sh'
+
+# call whatever was passed in
+eval "$@"
+

--- a/lcl-k8s4m.sh
+++ b/lcl-k8s4m.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# lcl-k8s4m.sh, ABr
+# Easy interface to bring local Kube-for-Mac Up/Down.
+# The nice thing about this script is that it waits for everything
+# to initialize cleanly, and installs Helm to the cluster if you
+# have installed Helm locally.
+#
+# How to use:
+# 1. Set variables for K8s version and location.
+#    See 'run-docker-kube-for-mac.sh' for info on what they are.
+#
+# 2. To start:
+#      lcl-k8s4m.sh start
+#
+# 3. To stop:
+#      lcl-k8s4m.sh stop
+#
+# "Start" brings up everything, including all post-Kubernetes
+# deployments (such as DNS and Dashboard).
+#
+# "Stop" brings down everything - do *not* count on any K8s
+# state being preserved (e.g. PVs, pod-ephemeral disks, etc.)
+
+# get vars we need (permit overrides)
+g_DOCKER_KUBE_FOR_MAC_K8S_VERSION=${DOCKER_KUBE_FOR_MAC_K8S_VERSION:-1.7.3}
+g_DOCKER_KUBE_FOR_MAC_LOCATION=${DOCKER_KUBE_FOR_MAC_LOCATION:-$(realpath .)}
+g_DOCKER_KUBE_FOR_MAC_CONTEXT=${DOCKER_KUBE_FOR_MAC_CONTEXT:-kube-for-mac}
+
+########################################################################
+# single deployment
+function lcl-k8s4m-i-deploy {
+  # args
+  local i_deploy_name="$1" ; shift
+  local i_custom_name="$1" ; shift
+
+  # locals
+  local l_deploy_line=''
+  local l_deploy_ready=0
+  local l_rc=0
+  local l_deploy_ready_lvalue=''
+  local l_deploy_ready_rvalue=''
+
+  echo -n "Deploy $*: "
+  l_deploy_line=$(kubectl --context=$g_DOCKER_KUBE_FOR_MAC_CONTEXT get deploy --namespace=kube-system $i_deploy_name 2>/dev/null | grep -e "$i_deploy_name")
+  if [ x"$l_deploy_line" = x ] ; then
+    echo ''
+    echo ''
+    "$g_DOCKER_KUBE_FOR_MAC_LOCATION"/hacks/v${g_DOCKER_KUBE_FOR_MAC_K8S_VERSION}/run ./run-docker-kube-for-mac.sh custom source /etc/hacks-in/hacks.sh DEPLOY-$i_custom_name
+  fi
+  l_deploy_ready=0
+  l_rc=0
+  while [ $l_deploy_ready -eq 0 ] ; do
+    l_deploy_line=$(kubectl --context=$g_DOCKER_KUBE_FOR_MAC_CONTEXT get deploy --namespace=kube-system $i_deploy_name 2>/dev/null | grep -e "$i_deploy_name")
+    l_rc=$?
+    if [ $l_rc -eq 0 ] ; then
+      if [ x"$l_deploy_line" != x ] ; then
+        l_deploy_ready_lvalue=$(echo "$l_deploy_line" | awk '{print $2}')
+        l_deploy_ready_rvalue=$(echo "$l_deploy_line" | awk '{print $5}')
+        [ x"$l_deploy_ready_lvalue" = x"$l_deploy_ready_rvalue" ] && l_deploy_ready=1
+      fi
+    fi
+    [ $l_deploy_ready -eq 0 ] && sleep 5 && echo -n '.'
+  done
+  echo 'OK'
+}
+
+########################################################################
+# start all - assumes from zero
+function lcl-k8s4m-x-start {
+  # start the cluster
+  "$g_DOCKER_KUBE_FOR_MAC_LOCATION"/hacks/v${g_DOCKER_KUBE_FOR_MAC_K8S_VERSION}/run ./run-docker-kube-for-mac.sh start
+
+  # locals
+  local l_ready=0
+  local l_comp_ready=0
+  local l_comp_line=''
+  local l_rc=0
+  local l_comp_ready_lvalue=''
+  local l_comp_ready_rvalue=''
+  local l_tmp_file=''
+
+  # all known controllers
+  echo ''
+  echo ''
+  echo -n 'Wait for k8s controllers: '
+  l_ready=0
+  while [ $l_ready -eq 0 ] ; do
+    l_ready=1
+    for i in k8s-master k8s-etcd k8s-proxy ; do
+      l_comp_ready=0
+      l_comp_line=$(kubectl --context=$g_DOCKER_KUBE_FOR_MAC_CONTEXT get pods --namespace=kube-system 2>/dev/null | grep -e "$i" | awk '{print $2}')
+      l_rc=$?
+      if [ $l_rc -eq 0 ] ; then
+        if [ x"$l_comp_line" != x ] ; then
+          l_comp_ready_lvalue=$(echo "$l_comp_line" | awk -F'/' '{print $1}')
+          l_comp_ready_rvalue=$(echo "$l_comp_line" | awk -F'/' '{print $2}')
+          [ x"$l_comp_ready_lvalue" = x"$l_comp_ready_rvalue" ] && l_comp_ready=1
+        fi
+      fi
+      [ $l_comp_ready -eq 0 ] && l_ready=0 && break
+    done
+    [ $l_ready -eq 0 ] && sleep 5 && echo -n '.'
+  done
+  echo 'OK'
+
+  # deploy addons
+  lcl-k8s4m-i-deploy 'kube-dns' 'DNS' 'DNS'
+  lcl-k8s4m-i-deploy 'kubernetes-dashboard' 'DASHBOARD' 'Dashboard'
+
+  # handle helm (tiller)
+  if hash helm ; then
+    l_comp_line=$(kubectl --context=$g_DOCKER_KUBE_FOR_MAC_CONTEXT get deploy tiller-deploy --namespace=kube-system 2>/dev/null | grep -e "tiller-deploy")
+    if [ x"$l_comp_line" = x ] ; then
+      helm init
+      l_rc=$?
+      [ $l_rc -ne 0 ] && echo "Failed helm init" && return $l_rc
+    fi
+
+    # wait for it to be ready...
+    echo -n 'Wait for helm tiller: '
+    l_comp_ready=0
+    while [ $l_comp_ready -eq 0 ] ; do
+      l_comp_line=$(kubectl --context=$g_DOCKER_KUBE_FOR_MAC_CONTEXT get deploy tiller-deploy --namespace=kube-system | grep -e "tiller-deploy")
+      [ x"$l_comp_line" = x ] && echo "Failed to locate tiller-deploy" && return $l_rc
+      l_comp_ready_lvalue=$(echo "$l_comp_line" | awk '{print $2}')
+      l_comp_ready_rvalue=$(echo "$l_comp_line" | awk '{print $5}')
+      [ x"$l_comp_ready_lvalue" = x"$l_comp_ready_rvalue" ] && l_comp_ready=1
+      [ $l_comp_ready -eq 0 ] && echo -n '.' && sleep 4
+    done
+    echo 'OK'
+  fi
+
+  # if we got here, we are OK
+  return 0
+}
+
+########################################################################
+# stop all
+function lcl-k8s4m-x-stop {
+  # start the cluster
+  "$g_DOCKER_KUBE_FOR_MAC_LOCATION"/hacks/v${g_DOCKER_KUBE_FOR_MAC_K8S_VERSION}/run ./run-docker-kube-for-mac.sh stop
+}
+
+########################################################################
+# optional call support
+l_do_run=0
+if [ "x$1" != "x" ]; then
+  [ "x$1" != "xsource-only" ] && l_do_run=1
+fi
+if [ $l_do_run -eq 1 ]; then
+  l_func="$1"; shift
+  [ x"$l_func" != x ] && eval lcl-k8s4m-x-"$l_func" "$@"
+fi
+

--- a/run-docker-kube-for-mac.sh
+++ b/run-docker-kube-for-mac.sh
@@ -4,9 +4,17 @@
 # See https://github.com/streamplace/kube-for-mac
 
 # HOW TO RUN:
-# 1. Determine your Kubernetes version (default value is *very old*)
+# 0. Don't call this script directly :)
+#    Instead, use the 'lcl-k8s4m.sh' wrapper we provide.
+#    Just use this script to get an idea of the env variables you can set.
 #
-#      DOCKER_KUBE_FOR_MAC_K8S_VERSION=1.7.0
+# 1. Determine your Kubernetes version (default value below is *very old*)
+#
+#      DOCKER_KUBE_FOR_MAC_K8S_VERSION=1.7.3
+#
+#    Turn on debug if you want *lots* of output
+#
+#      export DOCKER_KUBE_FOR_MAC_K8S_DEBUG=1
 #
 # 2. If necessary, create a wrapper script to load in any files or
 #    take other actions. For example, take a look at:
@@ -14,14 +22,15 @@
 #      ./hacks/v${DOCKER_KUBE_FOR_MAC_K8S_VERSION}/run
 #
 # 3. Start Kube-for-Mac (directly or using a wrapper script). The below
-#    uses a wrapper script to account for v1.7.0 we defined above:
+#    uses a wrapper script to account for v1.7.3 we defined above:
 #
 #      ./hacks/v${DOCKER_KUBE_FOR_MAC_K8S_VERSION}/run ./run-docker-kube-for-mac.sh start
 #
 #    Starting with k8s v1.7.0 things are broken. We had to do a lot of work.
-#    So there is *another* script to run to get addons deployed. Sigh.
+#    So there are *more* scripts to run for DNS and Dashboard. Sigh.
 #
-#      ./kube-for-mac/hacks/v${DOCKER_KUBE_FOR_MAC_K8S_VERSION}/run ./run-docker-kube-for-mac.sh custom source /etc/hacks-in/hacks.sh DEPLOY-ADDONS
+#      ./kube-for-mac/hacks/v${DOCKER_KUBE_FOR_MAC_K8S_VERSION}/run ./run-docker-kube-for-mac.sh custom source /etc/hacks-in/hacks.sh DEPLOY-DNS
+#      ./kube-for-mac/hacks/v${DOCKER_KUBE_FOR_MAC_K8S_VERSION}/run ./run-docker-kube-for-mac.sh custom source /etc/hacks-in/hacks.sh DEPLOY-DASHBOARD
 #      docker logs -f docker-kube-for-mac-custom
 #
 # 4. Smoketest if desired. The container should come into being, and should terminate properly.
@@ -45,9 +54,11 @@ g_DOCKER_KUBE_FOR_MAC_DOCKER_ARGS="${DOCKER_KUBE_FOR_MAC_DOCKER_ARGS}"
 g_DOCKER_KUBE_FOR_MAC_KUBELET_ARGS="${DOCKER_KUBE_FOR_MAC_KUBELET_ARGS}"
 g_DOCKER_KUBE_FOR_MAC_LOCAL_DOCKER_ARGS="${DOCKER_KUBE_FOR_MAC_LOCAL_DOCKER_ARGS}"
 g_DOCKER_KUBE_FOR_MAC_K8S_HACKS="${DOCKER_KUBE_FOR_MAC_K8S_HACKS}"
+g_DOCKER_KUBE_FOR_MAC_CONTROLLERS="scheduler kube-proxy kube-addon-manager"
+g_DOCKER_KUBE_FOR_MAC_K8S_DEBUG="${DOCKER_KUBE_FOR_MAC_K8S_DEBUG:-0}"
 
 ########################################################################
-# start
+# start all - assumes from zero
 function docker-kube-for-mac-x-start {
   local l_container_id=$(docker ps --quiet --filter name=docker-kube-for-mac-start 2>/dev/null)
   [ x"$l_container_id" != x ] && echo 'Container already running.' && return 1
@@ -56,6 +67,7 @@ function docker-kube-for-mac-x-start {
   local LOCAL_DOCKER_ARGS="$g_DOCKER_KUBE_FOR_MAC_DOCKER_ARGS"
   local LOCAL_KUBELET_ARGS="$g_DOCKER_KUBE_FOR_MAC_KUBELET_ARGS"
   local LOCAL_K8S_HACKS="$g_DOCKER_KUBE_FOR_MAC_K8S_HACKS"
+  local LOCAL_K8S_DEBUG="$g_DOCKER_KUBE_FOR_MAC_K8S_DEBUG"
 
   echo 'Starting kube-for-mac...'
   local l_docker_run="/tmp/kube-for-mac-$$.start"
@@ -66,6 +78,7 @@ function docker-kube-for-mac-x-start {
   echo "  -e K8S_VERSION=$g_DOCKER_KUBE_FOR_MAC_K8S_VERSION \\" >> "$l_docker_run"
   echo "  -e KUBELET_ARGS=\"$LOCAL_KUBELET_ARGS\" \\" >> "$l_docker_run"
   echo "  -e K8S_HACKS=\"$LOCAL_K8S_HACKS\" \\" >> "$l_docker_run"
+  echo "  -e K8S_DEBUG=\"$LOCAL_K8S_DEBUG\" \\" >> "$l_docker_run"
   echo "  $g_DOCKER_KUBE_FOR_MAC_IMAGE" >> "$l_docker_run"
   cat "$l_docker_run"
   source "$l_docker_run"
@@ -114,7 +127,7 @@ function docker-kube-for-mac-x-start {
 }
 
 ########################################################################
-# stop
+# stop - teardown cluster entirely
 function docker-kube-for-mac-x-stop {
   local l_docker_run="/tmp/kube-for-mac-$$.stop"
 
@@ -122,6 +135,7 @@ function docker-kube-for-mac-x-stop {
   local LOCAL_DOCKER_ARGS="$g_DOCKER_KUBE_FOR_MAC_DOCKER_ARGS"
   local LOCAL_KUBELET_ARGS="$g_DOCKER_KUBE_FOR_MAC_KUBELET_ARGS"
   local LOCAL_K8S_HACKS="$g_DOCKER_KUBE_FOR_MAC_K8S_HACKS"
+  local LOCAL_K8S_DEBUG="$g_DOCKER_KUBE_FOR_MAC_K8S_DEBUG"
 
   echo 'Stopping kube-for-mac...'
   echo "docker run --privileged -v /:/rootfs -v /Users:/Users --net=host \\" > "$l_docker_run"
@@ -131,6 +145,7 @@ function docker-kube-for-mac-x-stop {
   echo "  -e K8S_VERSION=$g_DOCKER_KUBE_FOR_MAC_K8S_VERSION \\" >> "$l_docker_run"
   echo "  -e KUBELET_ARGS=\"$LOCAL_KUBELET_ARGS\" \\" >> "$l_docker_run"
   echo "  -e K8S_HACKS=\"$LOCAL_K8S_HACKS\" \\" >> "$l_docker_run"
+  echo "  -e K8S_DEBUG=\"$LOCAL_K8S_DEBUG\" \\" >> "$l_docker_run"
   echo "  $g_DOCKER_KUBE_FOR_MAC_IMAGE stop" >> "$l_docker_run"
   cat "$l_docker_run"
   source "$l_docker_run"
@@ -180,6 +195,7 @@ function docker-kube-for-mac-x-custom {
   local LOCAL_DOCKER_ARGS="$g_DOCKER_KUBE_FOR_MAC_DOCKER_ARGS"
   local LOCAL_KUBELET_ARGS="$g_DOCKER_KUBE_FOR_MAC_KUBELET_ARGS"
   local LOCAL_K8S_HACKS="$g_DOCKER_KUBE_FOR_MAC_K8S_HACKS"
+  local LOCAL_K8S_DEBUG="$g_DOCKER_KUBE_FOR_MAC_K8S_DEBUG"
 
   echo 'Running custom kube-for-mac...'
   local l_docker_run="/tmp/kube-for-mac-$$.custom"
@@ -190,6 +206,7 @@ function docker-kube-for-mac-x-custom {
   echo "  -e K8S_VERSION=$g_DOCKER_KUBE_FOR_MAC_K8S_VERSION \\" >> "$l_docker_run"
   echo "  -e KUBELET_ARGS=\"$LOCAL_KUBELET_ARGS\" \\" >> "$l_docker_run"
   echo "  -e K8S_HACKS=\"$LOCAL_K8S_HACKS\" \\" >> "$l_docker_run"
+  echo "  -e K8S_DEBUG=\"$LOCAL_K8S_DEBUG\" \\" >> "$l_docker_run"
   echo "  $g_DOCKER_KUBE_FOR_MAC_IMAGE custom \\" >> "$l_docker_run"
   echo "  $@" >> "$l_docker_run"
   cat "$l_docker_run"
@@ -197,6 +214,215 @@ function docker-kube-for-mac-x-custom {
   local l_rc=$?
   rm -f "$l_docker_run"
   [ $l_rc -ne 0 ] && return $l_rc
+  return 0
+}
+
+########################################################################
+# docker container status
+function docker-kube-for-mac-i-docker-container-status {
+  local i_docker_container_id="$1"
+
+  # locals
+  local l_rc=0
+  local l_docker_container_is_running=''
+  local l_docker_container_is_paused=''
+
+  # analyze
+  l_docker_container_is_running="$(docker inspect -f {{.State.Running}} $i_docker_container_id)"
+  l_rc=$?
+  [ $l_rc -ne 0 ] && echo "Unknown Docker ID '$l_docker_container_id'" && return $l_rc
+  l_docker_container_is_paused="$(docker inspect -f {{.State.Paused}} $i_docker_container_id)"
+  l_rc=$?
+  [ $l_rc -ne 0 ] && echo "Unknown Docker ID '$l_docker_container_id'" && return $l_rc
+  if [ x"$l_docker_container_is_paused" = xtrue ] ; then
+    l_docker_container_status='paused'
+  elif [ x"$l_docker_container_is_running" = xtrue ] ; then
+    l_docker_container_status='running'
+  else
+    l_docker_container_status='stopped'
+  fi
+  echo "$l_docker_container_status"
+  return 0
+}
+
+########################################################################
+# pause a running cluster
+function docker-kube-for-mac-x-pause {
+  # get expected 'start' container - it must already be there
+  local l_start_container_id=$(docker ps -a --no-trunc --quiet --filter name=docker-kube-for-mac-start 2>/dev/null)
+  [ x"$l_start_container_id" = x ] && echo 'Start Container missing.' && return 1
+
+  # locals
+  local l_rc=0
+  local l_state_dir=''
+  local l_state_file=''
+  local l_tmp_file_prefix=''
+  local l_tmp_file_1=''
+  local l_tmp_file_2=''
+  local l_tmp_file_3=''
+  local l_tmp_file_4=''
+  local l_line_1=''
+  local l_line_2=''
+  local l_pod_namespace=''
+  local l_pod_name=''
+  local l_pod_container_name=''
+  local l_pod_container_id=''
+  local l_pod_container_status=''
+  local l_docker_pod_container_id=''
+  local l_docker_container_id=''
+  local l_docker_container_status=''
+  local l_kubelet_id=''
+
+  # temporary files
+  l_tmp_file_prefix="/tmp/docker-kube-for-mac-x-pause-$$"
+  l_tmp_file_sql="${l_tmp_file_prefix}.sql"
+  l_tmp_file_1="${l_tmp_file_prefix}.1"
+  l_tmp_file_2="${l_tmp_file_prefix}.2"
+  l_tmp_file_3="${l_tmp_file_prefix}.3"
+  l_tmp_file_4="${l_tmp_file_prefix}.4"
+
+  # stop kubelet first (no need for pause)
+  l_kubelet_id=$(docker ps -a --no-trunc --filter "name=kubelet" -q)
+  [ x"$l_kubelet_id" = x ] && echo 'Kubelet not available' && return 1
+  echo "Kubelet=$l_kubelet_id"
+  l_docker_container_status="$(docker-kube-for-mac-i-docker-container-status $l_kubelet_id)"
+  l_rc=$?
+  [ $l_rc -ne 0 ] && echo 'Failed query Kubelet' && rm -f ${l_tmp_file_prefix}* && return $l_rc
+  if [ x"$l_docker_container_status" = xrunning ] ; then
+    echo "  Stop Kubelet..."
+    docker stop $l_kubelet_id
+    l_rc=$?
+    [ $l_rc -ne 0 ] && echo 'Failed stopping Kubelet' && rm -f ${l_tmp_file_prefix}* && return $l_rc
+  fi
+
+  # state file to track docker IDs for restart
+  l_state_dir="$HOME/.docker-kube-for-mac"
+  l_state_file="${l_state_dir}/pause-state"
+  mkdir -p "$l_state_dir"
+  l_rc=$?
+  [ $l_rc -ne 0 ] && echo "Failed creating '$l_state_dir'" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+  echo '' > "$l_state_file"
+  l_rc=$?
+  [ $l_rc -ne 0 ] && echo "Failed accessing '$l_state_file'" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+  sqlite3 -column -header "$l_state_file" 'create table pause_state(ids integer primary key, namespace text, pod_name text, docker_pod_container_id text, container_name text, container_id text, state text);'
+
+  # save information on all known pods to state file
+  echo "Read all pod information..."
+  kubectl get pods --all-namespaces | tail -n +2 > "$l_tmp_file_1"
+  l_rc=$?
+  [ $l_rc -ne 0 ] && echo "Failed reading pod info" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+  while IFS='' read -r l_line_1 || [[ -n "$l_line_1" ]]; do
+    # extract basic kubernetes info
+    l_pod_namespace="$(echo "$l_line_1" | awk '{print $1}')"
+    l_pod_name="$(echo "$l_line_1" | awk '{print $2}')"
+
+    # for the current pod: read docker POD container (runs a 'pause' application')
+    l_docker_pod_container_id="$(docker ps -a --no-trunc | grep -e "$l_pod_name" | grep POD | awk '{print $1}')"
+    l_rc=$?
+    [ $l_rc -ne 0 ] && echo "Unable to locate Docker POD" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+
+    # extract expanded kubernetes info
+    echo "  Process $l_pod_namespace:$l_pod_name..."
+    kubectl get pod --namespace $l_pod_namespace -o json $l_pod_name > "$l_tmp_file_2"
+    l_rc=$?
+    [ $l_rc -ne 0 ] && echo "Failed reading pod info" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+    #cat "$l_tmp_file_2"
+
+    # extract the name, container ID, and running state as a single list with key/value pairs
+    jq '[.status.containerStatuses[] | {f1_name: .name, f2_id: .containerID, f3_state: [.state | to_entries[] | {key}][0].key}]' "$l_tmp_file_2" > "$l_tmp_file_3"
+    l_rc=$?
+    [ $l_rc -ne 0 ] && echo "Failed translating pod info to key/value pairs" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+    #cat "$l_tmp_file_3"
+
+    # convert the key/value pairs to CSV (double-quotes around each field; keys are sorted to known order)
+    jq -r '(map(keys) | add | unique | sort) as $cols | map(. as $row | $cols | map($row[.])) as $rows | $rows[] | @csv' "$l_tmp_file_3" > "$l_tmp_file_4"
+    l_rc=$?
+    [ $l_rc -ne 0 ] && echo "Failed translating pod info to CSV" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+    #cat "$l_tmp_file_4"
+
+    # process each line, which is made up of comma-delimited and *quoted* values
+    while IFS='' read -r l_line_2 || [[ -n "$l_line_2" ]]; do
+      l_pod_container_name="$(echo "$l_line_2" | awk -F'"' '{print $2}')"
+      l_pod_container_id="$(echo "$l_line_2" | awk -F'"' '{print $4}')"
+      l_pod_container_status="$(echo "$l_line_2" | awk -F'"' '{print $6}')"
+      #echo "l_pod_container_name='$l_pod_container_name'; l_pod_container_id='$l_pod_container_id'; l_pod_container_status='$l_pod_container_status'; l_docker_container_id='$l_docker_container_id'"
+
+      # now we need to translate the container ID (assume 'docker' format)
+      l_docker_container_id="$(echo "$l_pod_container_id" | sed -e 's#^docker://\(.*\)#\1#')"
+      #echo "l_docker_container_id='$l_docker_container_id'"
+
+      # query *docker* for the status (not kubernetes)
+      l_docker_container_status="$(docker-kube-for-mac-i-docker-container-status $l_docker_container_id)"
+      l_rc=$?
+      [ $l_rc -ne 0 ] && echo "Unknown Docker ID '$l_docker_container_id'" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+      #echo "l_docker_container_is_running='$l_docker_container_is_running'; l_rc='$l_rc'"
+      echo "    $l_pod_container_name: Status=$l_pod_container_status; ID=$l_docker_container_id ($l_docker_container_status)"
+
+      # we can finally generate the sql statement (dump any existing element)
+      echo "delete from pause_state where namespace='$l_pod_namespace' and pod_name='$l_pod_name' and container_name='$l_pod_container_name';" > "$l_tmp_file_sql"
+      echo 'insert into pause_state(namespace, pod_name, docker_pod_container_id, container_name, container_id, state)' >> "$l_tmp_file_sql"
+      echo "  values('$l_pod_namespace', '$l_pod_name', '$l_docker_pod_container_id', '$l_pod_container_name', '$l_docker_container_id', '$l_docker_container_status');" >> "$l_tmp_file_sql"
+      #cat "$l_tmp_file_sql"
+      sqlite3 "$l_state_file" < "$l_tmp_file_sql"
+      l_rc=$?
+      [ $l_rc -ne 0 ] && echo "Failed insert" && rm -f ${l_tmp_file_prefix}* && return $l_rc
+    done < "$l_tmp_file_4"
+  done < "$l_tmp_file_1"
+
+  # stop control programs
+  for i in $g_DOCKER_KUBE_FOR_MAC_CONTROLLERS ; do
+    # read the *pod* for this program
+    l_pod_name="$(sqlite3 "$l_state_file" "select distinct pod_name from pause_state where namespace='kube-system' and container_name='$i'")"
+    echo "Stop pod '$l_pod_name'..."
+
+    # stop the individual pods
+    for j in $(sqlite3 "$l_state_file" "select container_id from pause_state where namespace='kube-system' and pod_name='$l_pod_name'") ; do
+      l_docker_container_is_running="$(docker inspect -f {{.State.Running}} $j)"
+      if [ x"$l_docker_container_is_running" = xtrue ] ; then
+        docker stop $j
+      fi
+    done
+  done
+
+  # freeze (docker pause) all non-system pods
+  for i in $(sqlite3 "$l_state_file" "select container_id from pause_state where namespace!='kube-system'") ; do
+    l_docker_container_status="$(docker-kube-for-mac-i-docker-container-status $i)"
+    if [ x"$l_docker_container_status" != xpaused ] ; then
+      docker pause $i
+    fi
+  done
+
+  # stop everything else
+  for i in $(sqlite3 "$l_state_file" "select container_id from pause_state where namespace='kube-system'") ; do
+    l_docker_container_status="$(docker-kube-for-mac-i-docker-container-status $i)"
+    if [ x"$l_docker_container_status" = xrunning ] ; then
+      docker stop $i
+    fi
+  done
+
+  # pause the POD programs (STOP doesn't work)
+  for i in $(sqlite3 "$l_state_file" "select distinct docker_pod_container_id from pause_state") ; do
+    l_docker_container_status="$(docker-kube-for-mac-i-docker-container-status $i)"
+    if [ x"$l_docker_container_status" != xpaused ] ; then
+      docker pause $i
+    fi
+  done
+
+  # pause the 'start' container
+  l_docker_container_status="$(docker-kube-for-mac-i-docker-container-status $l_start_container_id)"
+  if [ x"$l_docker_container_status" != xpaused ] ; then
+    docker pause $l_start_container_id
+  fi
+
+  # stop the proxy containers
+  for i in k8s-proxy-1 k8s-proxy-2 ; do
+    l_docker_container_id=$(docker ps --no-trunc -a -f "name=$i" | grep -w "$i" | awk '{print $1}')
+    l_docker_container_status="$(docker-kube-for-mac-i-docker-container-status $l_docker_container_id)"
+    if [ x"$l_docker_container_status" = xrunning ] ; then
+      docker stop $l_docker_container_id
+    fi
+  done
+
   return 0
 }
 


### PR DESCRIPTION
For v1.7.3 - updated image versions in relevant manifests.

Automation:
1. cli.js - update to work with v1.7.3 and the new addon deployment. Although - due to timing it appears not to work :(
2. lcl-k8s4m.sh - like cli.js, except more configurable and accounts for timing
3. run-docker-kube-for-mac.sh - added 'pause' support and DEBUG flag. It also detects and deploys 'helm' if it is installed (the tiller component to K8s).

Finally - if you accept these changes don't forget to update the Docker image (changes to the common.sh script)